### PR TITLE
Optimize small window layout

### DIFF
--- a/FluentWeather/Views/MainPage.xaml
+++ b/FluentWeather/Views/MainPage.xaml
@@ -761,10 +761,8 @@
                         </RelativePanel>
 
 
-                        <StackPanel
-                            Grid.Row="1"
-                            Orientation="Horizontal">
-
+                        <GridView SelectionMode="None"
+                                  Grid.Row="1">
                             <controls:InsightControl x:Name="RunningInsight"></controls:InsightControl>
                             <controls:InsightControl x:Name="DrivingInsight"></controls:InsightControl>
 
@@ -775,9 +773,7 @@
                             <controls:InsightControl x:Name="WateringInsight"></controls:InsightControl>
 
                             <controls:InsightControl x:Name="DryskinInsight"></controls:InsightControl>
-
-
-                        </StackPanel>
+                        </GridView>
 
                     </Grid>
 
@@ -802,11 +798,8 @@
                         </RelativePanel>
 
 
-                        <StackPanel
-                            Grid.Row="1"
-                            Orientation="Horizontal">
-
-
+                        <GridView SelectionMode="None"
+                            Grid.Row="1">
                             <Grid
                                 Margin="4"
                                 CornerRadius="6"
@@ -1119,7 +1112,7 @@
 
                             </Grid>
 
-                        </StackPanel>
+                        </GridView>
 
                     </Grid>
 


### PR DESCRIPTION
Under a small window, some content will be obscured.

![image](https://github.com/Gabboxl/FluentWeather/assets/96322503/1eb32d82-6f24-40fc-885b-6680240f379c)

Using GridView to automatically wrap controls

![image](https://github.com/Gabboxl/FluentWeather/assets/96322503/63898ec2-3346-4daa-91fa-c4fc073ec7cf)
